### PR TITLE
Stdout bug fix and pass timeout as a param

### DIFF
--- a/bin/rspecq
+++ b/bin/rspecq
@@ -6,6 +6,7 @@ DEFAULT_REDIS_HOST = "127.0.0.1".freeze
 DEFAULT_REPORT_TIMEOUT = 3600 # 1 hour
 DEFAULT_MAX_REQUEUES = 3
 DEFAULT_FAIL_FAST = 0
+DEFAULT_QUEUE_TIMEOUT = 30
 
 def env_set?(var)
   ["1", "true"].include?(ENV[var])
@@ -96,6 +97,12 @@ OptionParser.new do |o|
     opts[:junit_output] = v
   end
 
+  o.on("--queue-ready-timeout N", Integer, "Time to wait for queue to be ready " \
+    "in N seconds "                                                             \
+    "(default: #{DEFAULT_QUEUE_TIMEOUT}).") do |v|
+    opts[:queue_ready_timeout] = v
+  end
+
   o.on_tail("-h", "--help", "Show this message.") do
     puts o
     exit
@@ -118,6 +125,7 @@ opts[:max_requeues] ||= Integer(ENV["RSPECQ_MAX_REQUEUES"] || DEFAULT_MAX_REQUEU
 opts[:redis_url] ||= ENV["RSPECQ_REDIS_URL"]
 opts[:fail_fast] ||= Integer(ENV["RSPECQ_FAIL_FAST"] || DEFAULT_FAIL_FAST)
 opts[:junit_output] ||= ENV["RSPECQ_JUNIT_OUTPUT"]
+opts[:queue_ready_timeout] ||= ENV["RSPECQ_QUEUE_TIMEOUT"] || DEFAULT_QUEUE_TIMEOUT
 
 # rubocop:disable Style/RaiseArgs, Layout/EmptyLineAfterGuardClause
 raise OptionParser::MissingArgument.new(:build) if opts[:build].nil?
@@ -167,5 +175,6 @@ else
   worker.max_requeues = opts[:max_requeues]
   worker.fail_fast = opts[:fail_fast]
   worker.junit_output = opts[:junit_output]
+  worker.queue_ready_timeout = opts[:queue_ready_timeout]
   worker.work
 end

--- a/lib/rspecq/formatters/junit_formatter.rb
+++ b/lib/rspecq/formatters/junit_formatter.rb
@@ -35,9 +35,22 @@ module RSpecQ
       end
 
       def examples
+        if @requeued_examples.size > 0
+          $stderr.puts "============ Example Notifications ============"
+          $stderr.puts @examples_notification.notifications.map { |en| log_example(en.example) }
+          $stderr.puts "============ Requeued Examples ================"
+          $stderr.puts @requeued_examples.map { |ex| log_example(ex) }
+        end
         @examples_notification.notifications.reject do |example_notification|
           @requeued_examples.map(&:id).include?(example_notification.example.id)
         end
+      end
+
+      def log_example(example)
+        $stderr.puts "----------"
+        $stderr.puts example.id
+        $stderr.puts example.inspect_output
+        $stderr.puts "----------"
       end
     end
   end

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -258,7 +258,9 @@ module RSpecQ
     end
 
     def rspec_dry_run_command(files)
-      "DISABLE_SPRING=1 bundle exec rspec --dry-run --format json #{files.join(' ')}"
+      cmd = "DISABLE_SPRING=1 bundle exec rspec --dry-run --format json #{files.join(' ')}"
+      $stderr.puts cmd
+      cmd
     end
 
     def relative_path(job)

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -54,6 +54,11 @@ module RSpecQ
     # on the number of test suites run in the current process.
     attr_accessor :junit_output
 
+    # Time to wait for worker queue to be ready
+    #
+    # Defaults to 30 seconds
+    attr_accessor :queue_ready_timeout
+
     # Optional arguments to pass along to rspec.
     #
     # Defaults to nil
@@ -72,6 +77,7 @@ module RSpecQ
       @heartbeat_updated_at = nil
       @max_requeues = 3
       @junit_output = nil
+      @queue_ready_timeout = 30
 
       RSpec::Core::Formatters.register(Formatters::JobTimingRecorder, :dump_summary)
       RSpec::Core::Formatters.register(Formatters::ExampleCountRecorder, :dump_summary)
@@ -84,7 +90,7 @@ module RSpecQ
       puts "Working for build #{@build_id} (worker=#{@worker_id})"
 
       try_publish_queue!(queue)
-      queue.wait_until_published
+      queue.wait_until_published(@queue_ready_timeout)
       idx = 0
       loop do
         # we have to bootstrap this so that it can be used in the first call

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -230,8 +230,7 @@ module RSpecQ
     # falling back to scheduling them as whole files. Their errors will be
     # reported in the normal flow when they're eventually picked up by a worker.
     def files_to_example_ids(files)
-      cmd = "DISABLE_SPRING=1 bundle exec rspec --dry-run --format json #{files.join(' ')}"
-      out, err, cmd_result = Open3.capture3(cmd)
+      out, err, cmd_result = Open3.capture3(rspec_dry_run_command(files))
 
       if !cmd_result.success?
         rspec_output = begin
@@ -253,7 +252,13 @@ module RSpecQ
         return files
       end
 
-      JSON.parse(out)["examples"].map { |e| e["id"] }
+      # strip extraneous output before json
+      rspec_json = out[out.index(/{.*version/)..-1]
+      JSON.parse(rspec_json)["examples"].map { |e| e["id"] }
+    end
+
+    def rspec_dry_run_command(files)
+      "DISABLE_SPRING=1 bundle exec rspec --dry-run --format json #{files.join(' ')}"
     end
 
     def relative_path(job)


### PR DESCRIPTION
# What does this do?
* Adds debug puts
* Fixes bug that occurs when dry run of rspec is parsed to split large files into individual spec examples. This bug occurs if some other gem adds output to stdout.
* Add the ability to configure the wait timeout for queue availability.